### PR TITLE
`duplicates()` now preserves groups and attributes for "regular" and "sf" data frames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyplus
 Title: Additional 'tidyverse' Functions
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = "aut",
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+# tidyplus 0.1.0.9000
+
+- `duplicates()` now preserves groups and attributes for "regular" and "sf" data frames.
+- Added tests for `duplicates()`.
+
 # tidyplus 0.1.0
 
 - Added the `str_replace_vec()` function.

--- a/R/duplicates.R
+++ b/R/duplicates.R
@@ -21,20 +21,25 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
   chk_flag(.keep_all)
 
   col <- rlang::ensyms(...)
-  if (length(col) == 0) { col_names <- colnames(.data) }
-  else { col_names <- vapply(col, rlang::as_string, character(1)) }
+  if (length(col) == 0) {
+    col_names <- colnames(.data)
+  } else {
+      col_names <- vapply(col, rlang::as_string, character(1))
+  }
   col_names <- unique(col_names)
   chk_vector(col_names)
   check_values(col_names, "")
   check_names(.data, col_names)
 
-  if (!length(col_names)) { return(.data) }
+  if (!length(col_names)) {
+    return(.data)
+  }
   
   grouped <- dplyr::is_grouped_df(.data)
   groups <- dplyr::group_vars(.data)
   groups_sym <- rlang::syms(groups)
   
-  is_sf = any(class(.data) == "sf")
+  is_sf <- any(class(.data) == "sf")
   
   .data <- tibble::as_tibble(.data)
   
@@ -43,8 +48,14 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
   .data_dup <- unique(.data_dup)
   
   .data <- dplyr::inner_join(.data, .data_dup, by = col_names) 
-  if (!(.keep_all)) { .data <- dplyr::select(.data, dplyr::all_of(col_names)) }
-  if (grouped) { .data <- dplyr::group_by(.data, !!!groups_sym) }
-  if (is_sf) { .data <- poisspatial::ps_activate_sfc(.data) }
+  if (!(.keep_all)) {
+    .data <- dplyr::select(.data, dplyr::all_of(col_names))
+  }
+  if (grouped) {
+    .data <- dplyr::group_by(.data, !!!groups_sym)
+  }
+  if (is_sf) {
+    .data <- poisspatial::ps_activate_sfc(.data)
+  }
   .data
 }

--- a/R/duplicates.R
+++ b/R/duplicates.R
@@ -58,7 +58,7 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
     .data <- dplyr::group_by(.data, !!!groups_sym)
   }
   if (is_sf) {
-    .data <- poisspatial::ps_activate_sfc(.data, sfc_name = col_name_sf)
+    .data <- sf::st_as_sf(.data, sf_column_name = col_name_sf)
   }
   .data
 }

--- a/R/duplicates.R
+++ b/R/duplicates.R
@@ -21,57 +21,30 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
   chk_flag(.keep_all)
 
   col <- rlang::ensyms(...)
-  if (length(col) == 0) {
-    col_names <- colnames(.data)
-  } else {
-    col_names <- vapply(col, rlang::as_string, character(1))
-  }
+  if (length(col) == 0) { col_names <- colnames(.data) }
+  else { col_names <- vapply(col, rlang::as_string, character(1)) }
   col_names <- unique(col_names)
-  
   chk_vector(col_names)
   check_values(col_names, "")
   check_names(.data, col_names)
 
-  if (!length(col_names)) {
-    return(.data)
-  }
+  if (!length(col_names)) { return(.data) }
   
   grouped <- dplyr::is_grouped_df(.data)
   groups <- dplyr::group_vars(.data)
   groups_sym <- rlang::syms(groups)
   
+  is_sf = any(class(.data) == "sf")
+  
+  .data <- tibble::as_tibble(.data)
+  
   .data_dup <- dplyr::select(.data, dplyr::all_of(col_names))
   .data_dup <- .data_dup[duplicated(.data_dup), , drop = FALSE]
   .data_dup <- unique(.data_dup)
   
-  is_sf = any(class(.data) == "sf")
-  if(is_sf)
-  {
-    .data <- poisspatial::ps_sfc_to_coords(.data)
-    .data_dup <- poisspatial::ps_sfc_to_coords(.data_dup)
-    if (any(col_names == "geometry")) {
-      col_names <- col_names[col_names != "geometry"]
-      col_names <- c(col_names, "X", "Y")
-    }
-  }
-  
   .data <- dplyr::inner_join(.data, .data_dup, by = col_names) 
-  if (!(.keep_all)) {
-    .data <- dplyr::select(.data, dplyr::all_of(col_names))
-  }
-  
-  if(is_sf) {
-    .data <- poisspatial::ps_coords_to_sfc(.data)
-  }
-  
-  .data <- dplyr::as_tibble(.data)
-  
-  if(is_sf) {
-    .data <- poisspatial::ps_activate_sfc(.data)
-  }
-  
-  if (grouped) {
-      .data <- dplyr::group_by(.data, !!!groups_sym)
-  }
+  if (!(.keep_all)) { .data <- dplyr::select(.data, dplyr::all_of(col_names)) }
+  if (grouped) { .data <- dplyr::group_by(.data, !!!groups_sym) }
+  if (is_sf) { .data <- poisspatial::ps_activate_sfc(.data) }
   .data
 }

--- a/R/duplicates.R
+++ b/R/duplicates.R
@@ -40,6 +40,9 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
   groups_sym <- rlang::syms(groups)
   
   is_sf <- any(class(.data) == "sf")
+  if (is_sf) {
+    col_name_sf <- attributes(.data)$sf_column
+  }
   
   .data <- tibble::as_tibble(.data)
   
@@ -55,7 +58,7 @@ duplicates <- function(.data, ..., .keep_all = TRUE) {
     .data <- dplyr::group_by(.data, !!!groups_sym)
   }
   if (is_sf) {
-    .data <- poisspatial::ps_activate_sfc(.data)
+    .data <- poisspatial::ps_activate_sfc(.data, sfc_name = col_name_sf)
   }
   .data
 }

--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -106,3 +106,9 @@ test_that("errors when input argument is not a data.frame", {
   expect_error(duplicates(NULL), "Data.frame must be a data.frame.")
   expect_error(duplicates(NA), "Data.frame must be a data.frame.")
 })
+
+test_that("preserves single active geometry column called geometry", {
+  skip_if_not_installed("sf")
+  data <- sf::st_sf(a=3, geometry = sf::st_sfc(sf::st_point(1:2)))
+  expect_identical(data, duplicates(data))
+})

--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -160,3 +160,33 @@ test_that("preserves single active geometry column called map", {
   
   expect_identical(data_dup, duplicates(data))
 })
+
+test_that("deals with one active geometry column and one inactive geometry column", {
+  skip_if_not_installed("sf")
+  
+  data <- tibble::tibble(
+    X = c(1, 2, 2, 3, 3, 4, 4),
+    Y = c(11, 12, 13, 14, 14, 15, 15),
+    a = c("red", "orange", "yellow", "green", "green", "blue", "blue"),
+    b = c("white", "white", "white", "white", "white", "white", "white"),
+    I = c(101, 102, 102, 103, 103, 104, 104),
+    J = c(1001, 1002, 1003, 1004, 1004, 1005, 1005)
+  )
+  data <- sf::st_as_sf(data, coords = c("X", "Y"))
+  data <- tibble::as_tibble(data)
+  data <- sf::st_as_sf(data, coords = c("I", "J"), sf_column_name = "map")
+  
+  data_dup <- tibble::tibble(
+    X = c(3, 3, 4, 4),
+    Y = c(14, 14, 15, 15),
+    a = c("green", "green", "blue", "blue"),
+    b = c("white", "white", "white", "white"),
+    I = c(103, 103, 104, 104),
+    J = c(1004, 1004, 1005, 1005)
+  )
+  data_dup <- sf::st_as_sf(data_dup, coords = c("X", "Y"))
+  data_dup <- tibble::as_tibble(data_dup)
+  data_dup <- sf::st_as_sf(data_dup, coords = c("I", "J"), sf_column_name = "map")
+  
+  expect_identical(data_dup, duplicates(data))
+})

--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -109,6 +109,37 @@ test_that("errors when input argument is not a data.frame", {
 
 test_that("preserves single active geometry column called geometry", {
   skip_if_not_installed("sf")
+  skip_if_not_installed("poisspatial")
   data <- sf::st_sf(a=3, geometry = sf::st_sfc(sf::st_point(1:2)))
+  data <- data[rep(1, 2), ]
+  rownames(data) <- NULL
+  data <- tibble::as_tibble(data)
+  data <- poisspatial::ps_activate_sfc(data)
   expect_identical(data, duplicates(data))
+})
+
+test_that("preserves groups and single active geometry column called earth", {
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("sf")
+  skip_if_not_installed("poisspatial")
+  
+  data <- data.frame(
+    X = c(1, 2, 2, 3, 3, 4, 4),
+    Y = c(11, 12, 13, 14, 14, 15, 15),
+    a = c("red", "orange", "yellow", "green", "green", "blue", "blue"),
+    b = c("white", "white", "white", "white", "white", "white", "white")
+  )
+  data <- dplyr::group_by(data, a, b)
+  data <- poisspatial::ps_coords_to_sfc(data, sfc_name = "earth")
+  
+  data_dup <- data.frame(
+    X = c(3, 3, 4, 4),
+    Y = c(14, 14, 15, 15),
+    a = c("green", "green", "blue", "blue"),
+    b = c("white", "white", "white", "white")
+  )
+  data_dup <- dplyr::group_by(data_dup, a, b)
+  data_dup <- poisspatial::ps_coords_to_sfc(data_dup, sfc_name = "earth")
+  
+  expect_identical(data_dup, duplicates(data))
 })

--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -105,6 +105,7 @@ test_that("preserves groups", {
     b = c("white", "white", "white", "white", "white", "white", "white")
   )
   data <- dplyr::group_by(data, a, b)
+  data <- duplicates(data)
   
   data_dup <- tibble::tibble(
     X = c(3, 3, 4, 4),
@@ -114,7 +115,7 @@ test_that("preserves groups", {
   )
   data_dup <- dplyr::group_by(data_dup, a, b)
   
-  expect_identical(data_dup, duplicates(data))
+  expect_identical(data_dup, data)
 })
 
 test_that("preserves single active geometry column called geometry", {
@@ -127,6 +128,7 @@ test_that("preserves single active geometry column called geometry", {
     b = c("white", "white", "white", "white", "white", "white", "white")
   )
   data <- sf::st_as_sf(data, coords = c("X", "Y"))
+  data <- duplicates(data)
   
   data_dup <- tibble::tibble(
     X = c(3, 3, 4, 4),
@@ -136,7 +138,7 @@ test_that("preserves single active geometry column called geometry", {
   )
   data_dup <- sf::st_as_sf(data_dup, coords = c("X", "Y"))
 
-  expect_identical(data_dup, duplicates(data))
+  expect_identical(data_dup, data)
 })
 
 test_that("preserves single active geometry column called map", {
@@ -149,6 +151,7 @@ test_that("preserves single active geometry column called map", {
     b = c("white", "white", "white", "white", "white", "white", "white")
   )
   data <- sf::st_as_sf(data, coords = c("X", "Y"), sf_column_name = "map")
+  data <- duplicates(data)
   
   data_dup <- tibble::tibble(
     X = c(3, 3, 4, 4),
@@ -158,7 +161,7 @@ test_that("preserves single active geometry column called map", {
   )
   data_dup <- sf::st_as_sf(data_dup, coords = c("X", "Y"), sf_column_name = "map")
   
-  expect_identical(data_dup, duplicates(data))
+  expect_identical(data_dup, data)
 })
 
 test_that("deals with one active geometry column and one inactive geometry column", {
@@ -175,6 +178,7 @@ test_that("deals with one active geometry column and one inactive geometry colum
   data <- sf::st_as_sf(data, coords = c("X", "Y"))
   data <- tibble::as_tibble(data)
   data <- sf::st_as_sf(data, coords = c("I", "J"), sf_column_name = "map")
+  data <- duplicates(data)
   
   data_dup <- tibble::tibble(
     X = c(3, 3, 4, 4),
@@ -188,5 +192,5 @@ test_that("deals with one active geometry column and one inactive geometry colum
   data_dup <- tibble::as_tibble(data_dup)
   data_dup <- sf::st_as_sf(data_dup, coords = c("I", "J"), sf_column_name = "map")
   
-  expect_identical(data_dup, duplicates(data))
+  expect_identical(data_dup, data)
 })


### PR DESCRIPTION
There might be some problems with the way I coded this for sf data frames.
1. `duplicates()` now uses poisspatial which we'd have to include as a tidyplus package dependency.
2. When dealing with sf data frames, `duplicates()` first converts the `geometry` sfc column back to `X` and `Y` coordinate columns, then does `dplyr::inner_join()` (because `dplyr::inner_join()` doesn't work on sf data frames), then converts the coordinate columns back to the sfc column. Unfortunately, this all hinges on the sf data frame having an sfc column named `geometry` meaning the user can't change the name of the column before calling `duplicates()`. We could add another argument to `duplicates()` to resolve this issue but I'm worried this might clutter the function call.

Alternatively, we could use `sf::st_join()`. However, I don't think we can pass specific columns to `sf::st_join()` like we can with `dplyr::inner_join()`.

Let me know what you both think and I'll start writing tests for the new `duplicates()` functionality.