### PR TITLE
Str_to_snakecase fix for additional underscores

### DIFF
--- a/R/add-missing-column.R
+++ b/R/add-missing-column.R
@@ -27,8 +27,9 @@
 #' # add_missing_column silently ignores
 #' add_missing_column(data, x = 4:6)
 add_missing_column <- function(
-    .data, ..., .before = NULL, .after = NULL,
-    .name_repair = c("check_unique", "unique", "universal", "minimal")) {
+  .data, ..., .before = NULL, .after = NULL,
+  .name_repair = c("check_unique", "unique", "universal", "minimal")
+) {
   if (!is.data.frame(.data)) {
     stop("add_column(.data = 'must be a data frame')")
   }

--- a/R/coalesce-data.R
+++ b/R/coalesce-data.R
@@ -36,7 +36,7 @@ coalesce_data <- function(x, coalesce = list(), quiet = FALSE) {
   chk_all(coalesce, chk_character)
   chk_all(coalesce, check_dim, values = TRUE)
   chk_all(coalesce, chk_not_any_na)
-  
+
   sf <- vld_s3_class(x, "sf")
 
   if (sf) {

--- a/R/if-else2.R
+++ b/R/if-else2.R
@@ -6,7 +6,7 @@
 #' [`str_detect2()`].
 #'
 #' @inherit dplyr::if_else
-#' @param error A logical value. If `TRUE`, provides an informative error message if no matches are found. 
+#' @param error A logical value. If `TRUE`, provides an informative error message if no matches are found.
 #' @return Where condition is `TRUE`, the matching value from `true`, where it's `FALSE` or `NA`, the matching value from `false`.
 #' @seealso [`ifelse()`] and [`dplyr::if_else()`].
 #' @export
@@ -36,8 +36,8 @@
 #'   x3 = dplyr::if_else(str_detect2(y, "x is false"), FALSE, x)
 #' )
 if_else2 <- function(condition, true, false, error = FALSE) {
-	chk_flag(error)
-  if (!any(condition) & error == TRUE) {
+  chk_flag(error)
+  if (!any(condition) && error == TRUE) {
     stop("No matches found. Did not make any replacements.")
   }
   dplyr::if_else(condition, true, false, missing = false)

--- a/R/str-to-snake-case.R
+++ b/R/str-to-snake-case.R
@@ -15,8 +15,11 @@
 #' str_to_snake_case(c("multiples of strings", "strings in multiple", "many strings"))
 #'
 str_to_snake_case <- function(x) {
-  snake_case_string <- gsub("[^A-Za-z0-9_ ]", "", x)
-  snake_case_string <- gsub(" ", "_", tolower(gsub("(.)([A-Z])", "\\1 \\2", snake_case_string)))
+  snake_case_string <- trimws(x)
+  snake_case_string <- gsub("[^A-Za-z0-9_ ]", "", snake_case_string)
+  snake_case_string <- gsub("\\s+", " ", snake_case_string)
+  snake_case_string <- gsub(" ", "_", tolower(gsub("(.)([A-Z])", "\\1_\\2", snake_case_string)))
+  snake_case_string <- gsub("_+", "_", snake_case_string)
   snake_case_string <- gsub("_$", "", snake_case_string)
   snake_case_string <- gsub("^_", "", snake_case_string)
   snake_case_string

--- a/R/str-to-snake-case.R
+++ b/R/str-to-snake-case.R
@@ -18,9 +18,8 @@ str_to_snake_case <- function(x) {
   snake_case_string <- trimws(x)
   snake_case_string <- gsub("[^A-Za-z0-9_ ]", "", snake_case_string)
   snake_case_string <- gsub("\\s+", " ", snake_case_string)
-  snake_case_string <- gsub(" ", "_", tolower(gsub("(.)([A-Z])", "\\1_\\2", snake_case_string)))
+  snake_case_string <- gsub(" ", "_", tolower(gsub("([a-z])([A-Z])", "\\1_\\2", snake_case_string)))
   snake_case_string <- gsub("_+", "_", snake_case_string)
-  snake_case_string <- gsub("_$", "", snake_case_string)
-  snake_case_string <- gsub("^_", "", snake_case_string)
+  snake_case_string <- gsub("^_|_$", "", snake_case_string)
   snake_case_string
 }

--- a/R/unite-str.R
+++ b/R/unite-str.R
@@ -18,7 +18,7 @@
 #'
 #' unite_str(data, "new", x, y, remove = FALSE)
 unite_str <- function(data, col, ..., sep = ". ", remove = TRUE) {
-  col <- rlang::ensym(col) 
+  col <- rlang::ensym(col)
   if (rlang::dots_n(...) == 0) {
     from_vars <- rlang::set_names(seq_along(data), names(data))
   } else {

--- a/man/only.Rd
+++ b/man/only.Rd
@@ -31,5 +31,5 @@ try(only(c(1, NA)))
 try(only(c(1, 2)))
 }
 \seealso{
-\code{\link[dplyr:nth]{dplyr::first()}}
+\code{\link[dplyr:first]{dplyr::first()}}
 }

--- a/man/str_crush.Rd
+++ b/man/str_crush.Rd
@@ -15,7 +15,7 @@ A character vector the same length as \code{string}.
 }
 \description{
 \code{str_crush()}, which removes all whitespace from a string,
-is the logical extension to \code{\link[stringr:str_trim]{stringr::str_trim()}} and \code{\link[stringr:str_trim]{stringr::str_squish()}}.
+is the logical extension to \code{\link[stringr:str_trim]{stringr::str_trim()}} and \code{\link[stringr:str_squish]{stringr::str_squish()}}.
 }
 \details{
 \code{str_crush()} is considered \href{https://github.com/tidyverse/stringr/pull/338}{too specialized} to be part of stringr.
@@ -24,5 +24,5 @@ is the logical extension to \code{\link[stringr:str_trim]{stringr::str_trim()}} 
 str_crush("  String with trailing,  middle, and leading white space\t")
 }
 \seealso{
-\code{\link[stringr:str_trim]{stringr::str_trim()}} and \code{\link[stringr:str_trim]{stringr::str_squish()}}
+\code{\link[stringr:str_trim]{stringr::str_trim()}} and \code{\link[stringr:str_squish]{stringr::str_squish()}}
 }

--- a/man/str_replace_vec.Rd
+++ b/man/str_replace_vec.Rd
@@ -23,7 +23,7 @@ String replace multiple strings in a vector.
 \details{
 \code{str_replace_vec()} is a vectorized form of \code{\link[stringr:str_replace]{stringr::str_replace()}}.
 
-This is different from passing a named vector to \code{\link[stringr:str_replace]{stringr::str_replace_all}},
+This is different from passing a named vector to \code{\link[stringr:str_replace_all]{stringr::str_replace_all}},
 which performs multiple replacements but to all pattern matches in a string.
 }
 \examples{
@@ -31,5 +31,5 @@ fruits <- c("two apples", "nine pears")
 str_replace_vec(fruits, c("two" = "three", "nine" = "ten"))
 }
 \seealso{
-\code{\link[stringr:str_replace]{stringr::str_replace()}} and \code{\link[stringr:str_replace]{stringr::str_replace_all()}}
+\code{\link[stringr:str_replace]{stringr::str_replace()}} and \code{\link[stringr:str_replace_all]{stringr::str_replace_all()}}
 }

--- a/man/summarise2.Rd
+++ b/man/summarise2.Rd
@@ -20,40 +20,28 @@ summary functions. The name will be the name of the variable in the result.
 The value can be:
 \itemize{
 \item A vector of length 1, e.g. \code{min(x)}, \code{n()}, or \code{sum(is.na(y))}.
-\item A data frame, to add multiple columns from a single expression.
-}
+\item A data frame with 1 row, to add multiple columns from a single expression.
+}}
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Returning values with size 0 or >1 was
-deprecated as of 1.1.0. Please use \code{\link[dplyr:reframe]{reframe()}} for this instead.}
-
-\item{.by}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
-
-<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, a selection of columns to
+\item{.by}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Optionally, a selection of columns to
 group by for just this operation, functioning as an alternative to \code{\link[dplyr:group_by]{group_by()}}. For
 details and examples, see \link[dplyr:dplyr_by]{?dplyr_by}.}
 
 \item{.groups}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Grouping structure of the
 result.
 \itemize{
-\item "drop_last": dropping the last level of grouping. This was the
+\item \code{"drop_last"}: drops the last level of grouping. This was the
 only supported option before version 1.0.0.
-\item "drop": All levels of grouping are dropped.
-\item "keep": Same grouping structure as \code{.data}.
-\item "rowwise": Each row is its own group.
+\item \code{"drop"}: All levels of grouping are dropped.
+\item \code{"keep"}: Same grouping structure as \code{.data}.
+\item \code{"rowwise"}: Each row is its own group.
 }
 
-When \code{.groups} is not specified, it is chosen
-based on the number of rows of the results:
-\itemize{
-\item If all the results have 1 row, you get "drop_last".
-\item If the number of rows varies, you get "keep" (note that returning a
-variable number of rows was deprecated in favor of \code{\link[dplyr:reframe]{reframe()}}, which
-also unconditionally drops all levels of grouping).
-}
-
-In addition, a message informs you of that choice, unless the result is ungrouped,
-the option "dplyr.summarise.inform" is set to \code{FALSE},
-or when \code{summarise()} is called from a function in a package.}
+When \code{.groups} is not specified, it is set to \code{"drop_last"} for a grouped
+data frame, and \code{"keep"} for a rowwise data frame. In addition, a message
+informs you of how the result will be grouped unless the result is
+ungrouped, the option \code{"dplyr.summarise.inform"} is set to \code{FALSE}, or when
+\code{summarise()} is called from a function in a package.}
 }
 \value{
 An object \emph{usually} of the same type as \code{.data}.
@@ -131,5 +119,5 @@ df |>
   dplyr::summarise(mean = mean(value))
 }
 \seealso{
-\code{\link[dplyr:summarise]{dplyr::summarise()}} and \code{\link[dplyr:summarise]{dplyr::summarize()}}
+\code{\link[dplyr:summarise]{dplyr::summarise()}} and \code{\link[dplyr:summarize]{dplyr::summarize()}}
 }

--- a/man/tidyplus-package.Rd
+++ b/man/tidyplus-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Ayla Pearson \email{ayla@poissonconsulting.ca} (\href{https://orcid.org/0000-0001-7388-1222}{ORCID})
   \item Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
 }
 

--- a/tests/testthat/test-add-missing-column.R
+++ b/tests/testthat/test-add-missing-column.R
@@ -38,7 +38,7 @@ test_that("add_missing_column ignores if present", {
 })
 
 test_that("add_missing_column no problem with existing and new column", {
-  data <- tibble::tibble(totalAssets = c(1,2))
+  data <- tibble::tibble(totalAssets = c(1, 2))
 
-  expect_identical(add_missing_column(data, totalAssets = NA_real_, other = 1), tibble::tibble(totalAssets = c(1,2), other = c(1, 1)))
+  expect_identical(add_missing_column(data, totalAssets = NA_real_, other = 1), tibble::tibble(totalAssets = c(1, 2), other = c(1, 1)))
 })

--- a/tests/testthat/test-coalesce-data.R
+++ b/tests/testthat/test-coalesce-data.R
@@ -7,7 +7,7 @@ test_that("coalesce_data unaltered with coalesce 1 column", {
   data <- data.frame(x = 1)
   expect_message(
     expect_identical(
-      coalesce_data(data, list(x = "x")), 
+      coalesce_data(data, list(x = "x")),
       data
     ),
     "Coalesced 'x' from: 'x'"
@@ -20,9 +20,9 @@ test_that("coalesce_data gets first non-missing", {
   new <- data.frame(z = 1)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'z' from: 'x' and 'y'"
   )
 })
@@ -33,9 +33,9 @@ test_that("coalesce_data sensitive to order of columns ", {
   new <- data.frame(z = 2)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'z' from: 'y' and 'x'"
   )
 })
@@ -46,9 +46,9 @@ test_that("coalesce_data handles all missing values of different class", {
   new <- data.frame(z = NA_character_)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'z' from: 'x' and 'y'"
   )
 })
@@ -59,9 +59,9 @@ test_that("coalesce_data can replace values with new one", {
   new <- data.frame(y = 1)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'y' from: 'x' and 'y'"
   )
 })
@@ -72,9 +72,9 @@ test_that("coalesce_data tags on end", {
   new <- data.frame(z = 3, y = 1)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'y' from: 'x' and 'y'"
   )
 })
@@ -85,9 +85,9 @@ test_that("coalesce_data overwrites existing column", {
   new <- data.frame(z = 1)
   expect_message(
     expect_identical(
-      coalesce_data(data, coalesce = coalesce), 
+      coalesce_data(data, coalesce = coalesce),
       new
-    ), 
+    ),
     "Coalesced 'z' from: 'x' and 'y'"
   )
 })
@@ -100,12 +100,13 @@ test_that("coalesce_data handles two coalesce values", {
     expect_message(
       expect_identical(
         coalesce_data(
-          data, 
+          data,
           coalesce = coalesce, quiet = FALSE
-        ), 
+        ),
         new
-      ), 
-    "Coalesced 'z' from: 'y' and 'x'"), "Coalesced 'd' from: 'z' and 'a'"
+      ),
+      "Coalesced 'z' from: 'y' and 'x'"
+    ), "Coalesced 'd' from: 'z' and 'a'"
   )
 })
 
@@ -116,7 +117,7 @@ test_that("coalesce_data quiet = FALSE", {
   expect_message(
     expect_message(
       coalesce_data(
-        data, 
+        data,
         coalesce = coalesce, quiet = FALSE
       ),
       "Coalesced 'z' from: 'y' and 'x'"
@@ -127,20 +128,21 @@ test_that("coalesce_data quiet = FALSE", {
 
 test_that("works with sf columns", {
   skip_if_not_installed("sf")
-  
+
   data <- data.frame(X = 1, Y = 2, z = 3, a = 4)
   data <- sf::st_as_sf(data, coords = c("X", "Y"), sf_column_name = "map")
   expect_message(
     data <- coalesce_data(
-      data, coalesce = list(d = c("z", "a")), 
+      data,
+      coalesce = list(d = c("z", "a")),
       quiet = FALSE
     ),
     "Coalesced 'd' from: 'z' and 'a'"
   )
-  
+
   output <- sf::st_as_sf(
-    tibble::tibble(X = 1, Y = 2, d = 3), 
-    coords = c("X", "Y"), 
+    tibble::tibble(X = 1, Y = 2, d = 3),
+    coords = c("X", "Y"),
     sf_column_name = "map"
   )
   output <- output[c(2, 1)]

--- a/tests/testthat/test-str-to-snake-case.R
+++ b/tests/testthat/test-str-to-snake-case.R
@@ -33,3 +33,9 @@ test_that("can input a multiple strings", {
   output <- str_to_snake_case(input)
   expect_equal(output, c("list_of_strings", "strings_in_a_list", "many_strings_in_a_list"))
 })
+
+test_that("removes punctuation followed by spaces", {
+  input <- "Removes @ Punctuation / and +spaces_ _"
+  output <- str_to_snake_case(input)
+  expect_equal(output, "removes_punctuation_and_spaces")
+})

--- a/tests/testthat/test-str-to-snake-case.R
+++ b/tests/testthat/test-str-to-snake-case.R
@@ -35,7 +35,13 @@ test_that("can input a multiple strings", {
 })
 
 test_that("removes punctuation followed by spaces", {
-  input <- "Removes @ Punctuation / and +spaces_ _"
+  input <- "Removes @ Punctuation / and +spaces_ "
   output <- str_to_snake_case(input)
   expect_equal(output, "removes_punctuation_and_spaces")
+})
+
+test_that("converts acronyms to snakecase without _", {
+  input <- "XYZ"
+  output <- str_to_snake_case(input)
+  expect_equal(output, "xyz")
 })


### PR DESCRIPTION
previous function was converting capital letters and punctuation to whitespace and as a result introducing too many underscores.

Example:
```
tester <- tibble::tribble(~`Test Area`, ~`Test ID / Site Name`, ~XYZ, ~`Test Value (x + y)`, ~MyTest)

colnames(tester)
[1] "Test Area"          
[2] "Test ID / Site Name"
[3] "XYZ"                
[4] "Test Value (x + y)" 
[5] "MyTest"           
  
tester %>% 
     dplyr::rename_with(str_to_snake_case) %>% 
     colnames()
[1] "test__area"           
[2] "test__id___site__name"
[3] "x_yz"                 
[4] "test__value_x__y"     
[5] "my_test"  
```

New version:
```
tester <- tibble::tribble(~`Test Area`, ~`Test ID / Site Name`,  ~XYZ, ~`Test Value (x + y)`, ~MyTest)

colnames(tester)
[1] "Test Area"          
[2] "Test ID / Site Name"
[3] "XYZ"                
[4] "Test Value (x + y)" 
[5] "MyTest"      
       
tester %>% 
     dplyr::rename_with(str_to_snake_case) %>% 
     colnames()
[1] "test_area"        
[2] "test_id_site_name"
[3] "xyz"              
[4] "test_value_x_y"   
[5] "my_test" 
```