### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7388-1222")),
-    person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "ctb",
+    person("Duncan", "Kennedy", role = "ctb",
            comment = c(ORCID = "0009-0001-4880-5751")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )


### PR DESCRIPTION
Remove Duncan Kennedy's email from DESCRIPTION.

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)