### PR TITLE
Update duplicates() error expectations for chk message change

### DIFF
--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -89,12 +89,12 @@ test_that("handles data set with no duplicates", {
 })
 
 test_that("errors when input argument is not a data.frame", {
-  expect_error(duplicates("a"), "`.data` must be a data.frame.")
-  expect_error(duplicates(1), "`.data` must be a data.frame.")
-  expect_error(duplicates(1L), "`.data` must be a data.frame.")
-  expect_error(duplicates(TRUE), "`.data` must be a data.frame.")
-  expect_error(duplicates(NULL), "`.data` must be a data.frame.")
-  expect_error(duplicates(NA), "`.data` must be a data.frame.")
+  expect_error(duplicates("a"), "must be a data.frame")
+  expect_error(duplicates(1), "must be a data.frame")
+  expect_error(duplicates(1L), "must be a data.frame")
+  expect_error(duplicates(TRUE), "must be a data.frame")
+  expect_error(duplicates(NULL), "must be a data.frame")
+  expect_error(duplicates(NA), "must be a data.frame")
 })
 
 test_that("preserves groups", {

--- a/tests/testthat/test-duplicates.R
+++ b/tests/testthat/test-duplicates.R
@@ -89,12 +89,12 @@ test_that("handles data set with no duplicates", {
 })
 
 test_that("errors when input argument is not a data.frame", {
-  expect_error(duplicates("a"), "Data.frame must be a data.frame.")
-  expect_error(duplicates(1), "Data.frame must be a data.frame.")
-  expect_error(duplicates(1L), "Data.frame must be a data.frame.")
-  expect_error(duplicates(TRUE), "Data.frame must be a data.frame.")
-  expect_error(duplicates(NULL), "Data.frame must be a data.frame.")
-  expect_error(duplicates(NA), "Data.frame must be a data.frame.")
+  expect_error(duplicates("a"), "`.data` must be a data.frame.")
+  expect_error(duplicates(1), "`.data` must be a data.frame.")
+  expect_error(duplicates(1L), "`.data` must be a data.frame.")
+  expect_error(duplicates(TRUE), "`.data` must be a data.frame.")
+  expect_error(duplicates(NULL), "`.data` must be a data.frame.")
+  expect_error(duplicates(NA), "`.data` must be a data.frame.")
 })
 
 test_that("preserves groups", {


### PR DESCRIPTION
## Summary

`chk` (dev `0.10.0.9027`) changes `check_data()` so it names the offending argument when passed a non-data frame, instead of reporting the literal `"Data.frame"`. This surfaced in a `chk` reverse-dependency check as a newly broken test in tidyplus.

- CRAN chk `0.10.0`: `Data.frame must be a data.frame.`
- dev chk: `` `.data` must be a data.frame. ``

The six `duplicates()` error expectations in `test-duplicates.R` now match on the substring `must be a data.frame`, so they pass against both the current CRAN chk and the dev version. tidyplus behavior is unchanged.

## Test plan

- `test-duplicates.R` passes against chk `0.10.0.9027` (FAIL 0 | PASS 30). The regex is a substring of both the CRAN and dev error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)